### PR TITLE
Use North American standard spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ nerd of nerds** at that time.
 [7 - My sense of humor](http://webofstories.com/play/17066)
 -----------------------------------------------------------
 
-Rather than sceptical, cynical, I would prefer satirical or something.
+Rather than skeptical, cynical, I would prefer satirical or something.
  
 KARAGUEUZIAN: Satirical. 
  


### PR DESCRIPTION
"skeptical" is the North American spelling of "sceptical", as part of [Websters' spelling reforms](http://english.stackexchange.com/questions/36749/why-did-sceptical-become-skeptical-in-the-us).
